### PR TITLE
A:varchasvnews.com

### DIFF
--- a/IndianList/specific_hide.txt
+++ b/IndianList/specific_hide.txt
@@ -943,7 +943,7 @@ agraleaks.com##.post-content > figure > img:only-child
 purvanchal24.com##.post-footer [trbidi]
 mannarkkadlive.com##.post-inner-image
 telugutimes.net##.post-sidebar-area
-todaysheoharnews.com,viznews.in##.prachar
+todaysheoharnews.com,varchasvnews.com,viznews.in##.prachar
 pchelpcenterbd.com##.pragads
 keralatimes.com##.prettyphoto
 kdnewslive.in##.progressContainer


### PR DESCRIPTION
found in url : https://varchasvnews.com/
https://varchasvnews.com/article/crisil-slashes-gdp-estimate-says-economy-may-decline-77-in-fy21-5fd8ae9d44599
![varchasvnews com 2020-12-15 18-16-27](https://user-images.githubusercontent.com/39060814/102217224-47adf780-3f02-11eb-8980-9fdd2cc59d85.png)
![varchasvnews com2020-12-15 18-15-36](https://user-images.githubusercontent.com/39060814/102217228-4977bb00-3f02-11eb-9ffb-fd7527631e39.png)

