### PR TITLE
A:biharnewslive.com

### DIFF
--- a/IndianList/specific_hide.txt
+++ b/IndianList/specific_hide.txt
@@ -132,7 +132,7 @@ sharebazarnews.com###custom_html-1371
 uluberiasambad.in###custom_html-14
 muznews.online,notunerkotha.com###custom_html-17
 bharatnewslive24.in,ggsnews24.com###custom_html-19
-amritvarshanews.in,buxaruptodate.com,ekushershokal.com,filmaniaentertainment.com,gharkavaidya.com,hastakshep.com,janadeshnews.in,januday.com,kishorgonj.com,kushtiabd.com,minoritiesnews.com,news127.com,newschutney.com,satyagrahanews.in,tamilvoicenews.com,thamilan.lk###custom_html-2
+amritvarshanews.in,biharnewslive.com,buxaruptodate.com,ekushershokal.com,filmaniaentertainment.com,gharkavaidya.com,hastakshep.com,janadeshnews.in,januday.com,kishorgonj.com,kushtiabd.com,minoritiesnews.com,news127.com,newschutney.com,satyagrahanews.in,tamilvoicenews.com,thamilan.lk###custom_html-2
 ptbnews.in###custom_html-2 img
 chhattisgarhvaibhav.com,satyaketansamachar.com,siwanonline.com###custom_html-21
 ddnews24x7.com###custom_html-26


### PR DESCRIPTION
found in url:https://biharnewslive.com/chapra-two-smugglers-arrested-red-handed-with-around-25-kg-of-silver-jewelery-from-freedom-fighter-express-train/
![biharnewslive com 2021-07-02 17-34-24](https://user-images.githubusercontent.com/39060814/124298998-8c397180-db7a-11eb-8e10-2e9098303cc5.png)
