### PR TITLE
A:khabreelal.com

### DIFF
--- a/IndianList/specific_block.txt
+++ b/IndianList/specific_block.txt
@@ -2060,6 +2060,7 @@ WebAd.jpg|$domain=vasundharadeep.news
 ||khabor.com^*/728%E0%A6%8290-ad.png
 ||khabor.com^*/USBD-Travels-and-tours-FLYERS-2019.png
 ||khaborbela.com/file/2019/08/bike.gif
+||khabreelal.com^*/uploaded_original/
 ||khasokhas.com/wp-content/uploads/2018/08/Girija-.jpg
 ||khasokhas.com/wp-content/uploads/2018/08/Manmohan-jee.jpg
 ||khasokhas.com/wp-content/uploads/2018/08/Sedie-.jpg


### PR DESCRIPTION
found in url:https://khabreelal.com/entertainment/saif-kareena-named-his-second-son-jahangir-there-was/cid4413732.htm
![khabreelal com 2021-08-13 17-09-31](https://user-images.githubusercontent.com/39060814/129449000-77fd5911-ec28-4592-bf26-f9559fae9dbb.png)
