### PR TITLE
A:policenama.com

### DIFF
--- a/IndianList/specific_block.txt
+++ b/IndianList/specific_block.txt
@@ -3147,6 +3147,7 @@ WebAd.jpg|$domain=vasundharadeep.news
 ||pnews.co.in/wp-content/uploads/2020/02/anigif-1.gif
 ||pnews24.com^*/risat-barisal.jpg
 ||podilitimes.com/wp-content/uploads/2017/07/add$image
+||policenama.com/wp-content/uploads/2019/06/Webp.net-gifmaker-1.gif
 ||policevarthe.com/wp-content/themes/police/images/ad1.jpg
 ||policevarthe.com/wp-content/themes/police/images/new-img/ad.jpg
 ||polikai.com^*/maestro-185-x-600.gif


### PR DESCRIPTION
found in url:https://policenama.com/pune-crime-shiba-kuriz-and-shiba-nidhi-chit-fund-scam-accused-hit-by-high-court-pune-police-appeals-to-investors/
![policenama com 2021-10-04 17-14-30](https://user-images.githubusercontent.com/39060814/135887926-b58dec49-85c8-40e4-ba24-0e6c0bedc94c.png)


