### PR TITLE
A:nainilive.com

### DIFF
--- a/IndianList/specific_hide.txt
+++ b/IndianList/specific_hide.txt
@@ -1858,6 +1858,7 @@ thirdeyetoday.com##.widget_youtube_responsive
 samridhjharkhand.com##.wiejqhgsp-container
 teluguwishesh.com##.wishesh-add
 madhyapradeshdarshan.com##.wonderpluginslider-container
+nainilive.com##.wp-block-image figure
 lokshakti.in##.wp-block-jetpack-slideshow
 indiapolkhol.in,pplnews.in##.wp-custom-header
 newssunamganj.com##.wp-image-10388
@@ -2204,6 +2205,7 @@ bikanerhulchul.com##div[class*="bikan"]
 dainikchintak.com##div[class*="daini-"]
 nrimalayalee.com##div[class*="inner-main-ad"]
 voiceofjhabua.com##div[class*="kitsune-adver"]
+nainilive.com##div[class*="naini-"]
 dainikpurbokone.net##div[class*="sgpb-popup"]
 attariyaonline.com##div[class*="sgpb-popup-"]
 sitamarhilive.in##div[class*="sitamarhi-livecontent_"]


### PR DESCRIPTION
found in url:https://nainilive.com/
https://nainilive.com/uttarakhand-high-court-removes-govt-of-uttar-pradesh-on-four-dham-yatra-lifts-boundary-of-scheduled-numbers-of-worshipers/
![nainilive com2021-10-06 16-08-20](https://user-images.githubusercontent.com/39060814/136187659-681aa6cc-e03a-4ffd-b948-69532d8abdbc.png)
![nainilive com 2021-10-05 17-16-24](https://user-images.githubusercontent.com/39060814/136187667-0b55d30f-cdd8-46d0-ae4e-79ebc540b84b.png)


