### PR TITLE
A:keralaonlinenews.com

### DIFF
--- a/IndianList/specific_hide.txt
+++ b/IndianList/specific_hide.txt
@@ -1391,6 +1391,7 @@ prabartan.com##.kc_single_image
 karobardaily.com##.kd-ad-horizontal
 khabardabali.com##.kdb-topAdd
 filmcityworld.com##.kenm
+keralaonlinenews.com##.keral-beforecontent
 keralaonlinenews.com##.keral-widget
 khabarpahad.com##.khaba-widget
 khabarhub.com##.khabarhub-inner-ads


### PR DESCRIPTION
found in url:https://keralaonlinenews.com/2022/02/01/musical-instruments-scheduled-caste-groups-kasargod.html
![keralaonlinenews com-2022-02-01-10-51-47](https://user-images.githubusercontent.com/39060814/151989957-9cfc205a-a395-4fad-b3d5-8c508e520c19.png)

