### PR TITLE
A:newstodaycg.com

### DIFF
--- a/IndianList/specific_hide.txt
+++ b/IndianList/specific_hide.txt
@@ -512,6 +512,7 @@ silkcitynews.com###sidebar-primary aside.widget_media_image
 haryananewsonline.com###sidebar-primary-sidebar
 mynews36.com###sidebar-primary-sidebar .widget_custom_html
 channelionline.com,hind24news.com,npg.news###sidebar-primary-sidebar .widget_media_image
+newstodaycg.com###sidebar-primary-sidebar > .widget:not([id^="bs-"])
 khabarcgnews.com###sidebar-right .widget_block
 khamoshduniya.com###sidebar-right .widget_custom_html
 24x7cg.com###sidebar-right .widget_custom_html:not(#custom_html-33)


### PR DESCRIPTION
found in url:https://www.newstodaycg.com/icc-womens-cricket-world-cup-india-pakistan-clash-will-be-held-on-the-cricket-field-on-march-6/
![newstodaycg com-2022-03-02-21-54-21](https://user-images.githubusercontent.com/39060814/156403752-545232d9-55c2-4154-9927-89a9f092988e.png)
![newstodaycg com-2022-03-02-21-54-06](https://user-images.githubusercontent.com/39060814/156403763-4500070d-1443-4e82-b51e-4bcf8504c9ea.png)

