### PR TITLE
A:news127.com

### DIFF
--- a/IndianList/specific_block.txt
+++ b/IndianList/specific_block.txt
@@ -2835,6 +2835,7 @@ WebAd.jpg|$domain=vasundharadeep.news
 ||newcinemaexpress.com/wp-content/uploads/2021/02/anbirkiniyal-bg-ad.jpg
 ||newneervely.com/wp-content/uploads/2020/04/web-240x300.jpg
 ||newneervely.com/wp-content/uploads/2020/04/web.jpg
+||news127.com/wp-content/uploads/2022/03/WhatsApp-Image-2022-03-09-at-09.05.42.jpeg
 ||news129.com/wp-content/uploads/2021/01/WhatsApp-Image-2021-01-21-at-20.44.06
 ||news13.in/wp-content/uploads/2017/03/Paigrp
 ||news1hindustan.com^*/add-durgesh-


### PR DESCRIPTION
found in url:https://news127.com/those-who-shot-at-the-dean-of-agricultural-university-were-caught-the-name-of-the-female-professor-of-the-college-surfaced-in-the-conspiracy/
![news127 com-2022-03-24-19-16-14](https://user-images.githubusercontent.com/39060814/160148962-91e8ad81-0c73-432f-8a55-0d4b60633d4b.png)

