### PR TITLE
A:balliakhabar.com

### DIFF
--- a/IndianList/specific_block.txt
+++ b/IndianList/specific_block.txt
@@ -2004,6 +2004,7 @@ WebAd.jpg|$domain=vasundharadeep.news
 ||kaumudiplus.com^*/awc-banner.jpg
 ||kaumudiplus.com^*/chemmannurfin1.jpg
 ||kazirbazar.com^*/ad-1.jpg
+||kbuccket.sgp1.digitaloceanspaces.com/balliakhabar/2022/04/03153431/Milk
 ||kelimandala.lankadeepa.lk^*/advr_
 ||keralaexpress.com^*/banners
 ||keralanewshunt.com/images/coirfed%20cut.jpg


### PR DESCRIPTION
found in url:https://balliakhabar.com/ballia-ravi-shankar-singh-pappu-becomes-mlc-for-fourth-consecutive-term/
![balliakhabar com-2022-04-12-18-44-26](https://user-images.githubusercontent.com/39060814/163234709-85d7cb05-db37-416b-975b-ee67e8b1eb0d.png)

