### PR TITLE
A:arlivenews.com

### DIFF
--- a/IndianList/specific_block.txt
+++ b/IndianList/specific_block.txt
@@ -353,7 +353,11 @@ WebAd.jpg|$domain=vasundharadeep.news
 ||appusami.com^*/Thejomaya%20Ad2.jpg
 ||appusami.com^*/thejomayaad3.jpg
 ||appusami.com^*/yogesh.jpg
+||arlivenews.com^*-ad-
+||arlivenews.com^*/bhagvat-
+||arlivenews.com^*/MOKSHI-
 ||arlivenews.com^*/sojatia-
+||arlivenews.com^*/udaipur-badgaon
 ||arthadaily.com/users_upload/simrik-air.gif
 ||arthosuchak.com/wp-content/uploads/2021/05/Ucb-web-banner.jpg
 ||arthparkash.com/wp-content/uploads/2020/03/brijvashi_.jpg

--- a/IndianList/specific_hide.txt
+++ b/IndianList/specific_hide.txt
@@ -2777,6 +2777,7 @@ dailysobujbarta.com##figure.vc_figure
 dainikkushtia.net,news27.org##figure.wp-block-image
 dailybahadur.com##figure.wp-block-image > img
 reportersnepal.com,vtvvitla.com##figure.wp-block-image.size-large
+arlivenews.com##figure.wp-block-image.size-large img:not([src*=udaipur-uit-])
 sanvadnews.com##figure.wp-block-table
 buxaruptodate.com,samastipurtown.com##figure.wp-caption
 samajbad.tv##figure.wpb_wrapper


### PR DESCRIPTION
found in url:https://arlivenews.com/2022/04/12/two-died-and-46-rescued-in-deoghar-ropeway-accident/
https://arlivenews.com/category/home/
![arlivenews com-2022-04-12-18-22-36](https://user-images.githubusercontent.com/39060814/163419518-f0e9a186-afa7-4d07-ae82-a2111c9d0235.png)
![arlivenews com-2022-04-12-18-22-22](https://user-images.githubusercontent.com/39060814/163419524-a4d15ccb-dc08-4fa2-89ee-a696312c8a67.png)

