### PR TITLE
A:jansatta.com

### DIFF
--- a/IndianList/specific_hide.txt
+++ b/IndianList/specific_hide.txt
@@ -1200,6 +1200,7 @@ ekantipur.com##.daraz-sponser
 deshabhimani.com##.db-scnAd2
 ddnews24x7.com##.ddnew-after-content
 bholarbani.com##.default-advertise
+jansatta.com##.desk-ad-bg-container
 kholakagojbd.com,poriborton.com##.desktop-ad-nilsagor
 baahrakhari.com##.detail-bigyapan
 ekusheysangbad.com##.details-big-banner


### PR DESCRIPTION
found in url:https://www.jansatta.com/entertainment/the-kashmir-files-row-congress-leader-shashi-tharoor-slams-vivek-agnihotri-and-anupam-kher/2168622/
![jansatta com-2022-05-11-12-01-35](https://user-images.githubusercontent.com/39060814/168091714-89c24a65-ace1-46a7-93a3-5e66a034df5c.png)

