### PR TITLE
A:vatsalyanews.com

### DIFF
--- a/IndianList/specific_hide.txt
+++ b/IndianList/specific_hide.txt
@@ -2191,6 +2191,7 @@ rsnewslive.com##.unite-gallery
 valaitamil.com##.upper_links
 newstodayjharkhand.com##.uris-slider-post-title
 newskranti.com##.utt_top
+vatsalyanews.com##.vatsa-middle
 kanakaikhabar.com##.vc_column-inner .wpb_gallery
 changetv.press##.vc_custom_1546328500609
 netmalayalam.com##.vc_figure


### PR DESCRIPTION
found in url:https://vatsalyanews.com/2022/06/07/nusrat-zaha-pathan-gets-3-percentile-in-kalol-muslim-samajs-pride-board-exam/
![vatsalyanews com-2022-06-07-16-27-45](https://user-images.githubusercontent.com/39060814/172363501-fbc0085b-cae8-4769-bc54-4d6d2108827e.png)

