### PR TITLE
A:arlivenews.com

### DIFF
--- a/IndianList/specific_block.txt
+++ b/IndianList/specific_block.txt
@@ -380,8 +380,11 @@ WebAd.jpg|$domain=vasundharadeep.news
 ||appusami.com^*/thejomayaad3.jpg
 ||appusami.com^*/yogesh.jpg
 ||ararianews.com/wp-content/uploads/2022/09/bpsc-batch-perfection-ias.jpg
+||arlivenews.com/wp-content/uploads/2022/07/20220714_193742.gif
+||arlivenews.com/wp-content/uploads/2022/08/wonder-cement
 ||arlivenews.com^*-ad-
 ||arlivenews.com^*/bhagvat-
+||arlivenews.com^*/highlight
 ||arlivenews.com^*/MOKSHI-
 ||arlivenews.com^*/sojatia-
 ||arlivenews.com^*/udaipur-badgaon


### PR DESCRIPTION
found in utl:https://arlivenews.com/2022/10/15/us-president-biden-called-pakistan-one-of-the-most-dangerous-countries-in-the-world/
https://arlivenews.com/2022/10/15/us-president-biden-called-pakistan-one-of-the-most-dangerous-countries-in-the-world/
![arlivenews com-2022-10-15-18-36-58](https://user-images.githubusercontent.com/39060814/196195817-d35eee8e-c7e5-4a55-8f10-66e8b0e072dd.png)
