### PR TITLE
A:newsagencyindia.com

### DIFF
--- a/IndianList/specific_hide.txt
+++ b/IndianList/specific_hide.txt
@@ -2437,6 +2437,7 @@ karmalamadhanews24.com,pioneerhindi.com,tnilive.com##.vmagazine_lite_medium_ad
 hpnewsatl.com,janatatimes.com,namasteholland.com,vaarte.com##.vmagazine_medium_ad
 kositimes.com##.vqtu
 vishwavani.news##.vv_advst
+newsagencyindia.com##.w-100
 rajpathmathura.com,thaiveedu.com##.wds_slider_cont
 eisamay.com,iamgujarat.com,maharashtratimes.com,samayam.com##.wdt_amz
 hajurkokhabar.com##.web__banner


### PR DESCRIPTION
found in url:https://newsagencyindia.com/udaipur/udaipurs-pichola-water-is-not-even-bathable-pollution-control-boards-rti-disclosed
![newsagencyindia com-2022-10-15-18-44-43](https://user-images.githubusercontent.com/39060814/196196930-01f2e4df-8bfd-47a0-a9c9-83216e4fe505.png)
