### PR TITLE
A:suddione.com

### DIFF
--- a/IndianList/specific_hide.txt
+++ b/IndianList/specific_hide.txt
@@ -2240,6 +2240,7 @@ bundelkhandsamachar.com##.stream-item:not(.stream-item-top-wrapper)
 timenewsbd.net##.stretched_link
 youthmukam.com##.su-image-carousel
 hetaudatoday.com##.subhakamana-ad
+suddione.com##.suddi-content_19
 awajnews.com##.supsystic-slider-wrapper
 ibctamil.com##.t-eds
 notebook.today##.t-out-span


### PR DESCRIPTION
found in url:https://suddione.com/at-least-46-dead-over-700-injured-as-5-6-magnitude-earthquake-jolts-indonesia/
![suddione com-2022-11-18-20-42-24](https://user-images.githubusercontent.com/39060814/203349711-0fbb7e28-fff6-4a80-b1fb-a05365ffc680.png)
