### PR TITLE
adblock plus included

### DIFF
--- a/IndianList/adservers.txt
+++ b/IndianList/adservers.txt
@@ -1,3 +1,10 @@
+[Adblock Plus 2.0]
+! Version: 
+! Title: IndianList AdServers
+! Last modified: 
+! Expires: 7 days (update frequency)
+! Homepage: 
+!
 ||admana.net$third-party
 ||admitad.com^$third-party,domain=hellonepalkorea.com
 ||ads2publish.com^$third-party

--- a/IndianList/cdn_block.txt
+++ b/IndianList/cdn_block.txt
@@ -1,3 +1,10 @@
+[Adblock Plus 2.0]
+! Version: 
+! Title: IndianList CDN_Block
+! Last modified: 
+! Expires: 7 days (update frequency)
+! Homepage: 
+!
 @@||i0.wp.com/www.tajakhabaruttarakhand.com/wp-content/uploads/2021/11/advt.jpeg
 ||1.bp.blogspot.com/--9YBT8j6pmI/X4ar3RmtNVI/AAAAAAABsAM/R2B1R2Y1nwE-aS_qJgsTIuPWZkstydYAACLcBGAsYHQ/s1200/1200x100px.gif
 ||1.bp.blogspot.com/-089XEgQTbfM/XYtpWNkrVWI/AAAAAAAAE7Y/YdBehnrpHDE6HgZEe8wYH_CU8MX1glXVgCLcBGAsYHQ/s1600/smart-plan-engineers-plan-estimate-kumbla.jpg

--- a/IndianList/general_block.txt
+++ b/IndianList/general_block.txt
@@ -1,3 +1,10 @@
+[Adblock Plus 2.0]
+! Version: 
+! Title: IndianList General
+! Last modified: 
+! Expires: 7 days (update frequency)
+! Homepage: 
+!
 -ad-mob
 -ad-space-
 -advt-

--- a/IndianList/specific_block.txt
+++ b/IndianList/specific_block.txt
@@ -1,3 +1,10 @@
+[Adblock Plus 2.0]
+! Version: 
+! Title: IndianList Specific_block
+! Last modified: 
+! Expires: 7 days (update frequency)
+! Homepage: 
+!
 -1024x1024.jpeg|$domain=muzaffarpurnow.in|muznow.in
 -1024x256$domain=dailyfenchugonj.com
 -500x300$domain=khojinews.co.in

--- a/IndianList/specific_hide.txt
+++ b/IndianList/specific_hide.txt
@@ -1,3 +1,10 @@
+[Adblock Plus 2.0]
+! Version: 
+! Title: IndianList Specific_hide
+! Last modified: 
+! Expires: 7 days (update frequency)
+! Homepage: 
+!
 livebihar24news.com###AD_FLOAT
 eelamtimes.com###AutoNumber1
 bdipo.com###BDIPO_ad_id


### PR DESCRIPTION
This submit included adblock plus comments in the txt files. So that we can directly use these files in adblock plus extension in chrome/firefox or any other supported browsers as well. 

Ref:
https://helpcenter.getadblock.com/hc/en-us/articles/9738523347219-How-to-create-your-own-personal-filter-list#:~:text=%5BAdblock%20Plus%202.0%5D%0A!%20Version%3A%20%0A!%20Title%3A%20My%20Personal%20Filter%20List%0A!%20Last%20modified%3A%20%0A!%20Expires%3A%207%20days%20(update%20frequency)%0A!%20Homepage%3A%20%0A!