### PR TITLE
A:newshomelive.co.in

### DIFF
--- a/IndianList/specific_hide.txt
+++ b/IndianList/specific_hide.txt
@@ -2458,6 +2458,7 @@ i-news24.com##.newsbox_text
 chandpurprobaha.com##.newscard-widget-ad
 newsdiary.live##.newsd-widget
 jharkhandvani.in##.newsever-widget .textwidget
+newshomelive.co.in##.newsh-after-content_5
 expressindian.co.in##.newshit-header-ads-wrapper
 newskannada.com##.newsk-content
 satyagrahanews.in##.newsmatic-advertisement-block


### PR DESCRIPTION
found in url:https://www.newshomelive.co.in/
https://www.newshomelive.co.in/former-chief-minister-harish-rawat-reached-the-tharali-nyaya-yatra-accused-of-serving-lies-on-bjp/
![newshomelive co in2025-06-12 21-30-15](https://github.com/user-attachments/assets/c3eb8e60-c757-4b33-816e-ba6b88ea7bd6)

